### PR TITLE
Custom Exception

### DIFF
--- a/src/ExceptionFailedToSendEmail.php
+++ b/src/ExceptionFailedToSendEmail.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * A custom exception to raise if email sending fails.
+ * Using a custom exception, allows the developer to gracefully handle different erroneous situations at a higher level.
+ */
+
+namespace iRAP\Emailers;
+
+class ExceptionFailedToSendEmail extends \Exception
+{
+
+}
+
+

--- a/src/PhpMailerEmailer.php
+++ b/src/PhpMailerEmailer.php
@@ -68,7 +68,7 @@ class PhpMailerEmailer implements EmailerInterface
      * @param string $subject - subject of the email
      * @param string $message - plaintext or html body of the email.
      * @param bool $html_format - whether the email is html or not (defaults to true)
-     * @throws \Exception - if failed to send the email for whatever reason.
+     * @throws ExceptionFailedToSendEmail - if failed to send the email for whatever reason.
      */
     public function send($to_name, $to_email, $subject, $message, $html_format = true) 
     {
@@ -96,5 +96,4 @@ class PhpMailerEmailer implements EmailerInterface
         } 
     }
 }
-
 

--- a/src/PhpMailerEmailer.php
+++ b/src/PhpMailerEmailer.php
@@ -92,10 +92,9 @@ class PhpMailerEmailer implements EmailerInterface
         
         if (!$mailer->send()) 
         {
-            throw new \Exception("Failed to send email: " . $mailer->ErrorInfo);
+            throw new ExceptionFailedToSendEmail("Failed to send email: " . $mailer->ErrorInfo);
         } 
     }
 }
-
 
 

--- a/src/SmtpEmailer.php
+++ b/src/SmtpEmailer.php
@@ -83,7 +83,7 @@ class SmtpEmailer implements EmailerInterface
 
         if (PEAR::isError($mail)) 
         {
-            throw new \Exception('Error sending email: ' . $mail->getMessage());
+            throw new ExceptionFailedToSendEmail('Error sending email: ' . $mail->getMessage());
         } 
     }    
 }

--- a/src/SmtpEmailer.php
+++ b/src/SmtpEmailer.php
@@ -52,6 +52,7 @@ class SmtpEmailer implements EmailerInterface
      * @param string $subject - the subject of the email
      * @param string $message - the body of the email
      * @param bool $html_format - optional - set to false if you must send plaintext, html assumed
+     * @throws ExceptionFailedToSendEmail - if sending the email fails.
      */
     public function send($to_name, $to_email, $subject, $message, $html_format=true)
     {


### PR DESCRIPTION
The following pull request changes the package from throwing a generic \Exception to a custom one specific for failing to send an email. I needed to implement this for another project so that I could gracefully handle various different things possibly going wrong at a higher level. Thus one can distinguish between an email not sending, or some other generic exception.
