### PR TITLE
Update to the version of PHPMailer required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "phpmailer/phpmailer": "6.1.*"
+        "phpmailer/phpmailer": "^6.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
PHPMailer has been updated to 6.4 via maintenance and security releases. 
See ( https://github.com/PHPMailer/PHPMailer/releases ).
I am 'assuming' none of the updates to PHPMailer affect actual functionality.